### PR TITLE
Add support for processing inline expressions for message properties

### DIFF
--- a/.connector-store/meta.json
+++ b/.connector-store/meta.json
@@ -16,7 +16,7 @@
     ],
     "releases": [
         {
-            "tagName": "v0.9.3",
+            "tagName": "v0.9.4",
             "products": [
                 "MI 4.4.0"
             ],

--- a/src/main/java/org/wso2/integration/connector/PulsarConfig.java
+++ b/src/main/java/org/wso2/integration/connector/PulsarConfig.java
@@ -181,8 +181,6 @@ public class PulsarConfig extends AbstractConnector implements ManagedLifecycle 
         config.setTlsTrustStorePassword((String) getParameter(messageContext,
                 PulsarConstants.TLS_TRUST_STORE_PASSWORD));
         config.setTlsTrustStoreType((String) getParameter(messageContext, PulsarConstants.TLS_TRUST_STORE_TYPE));
-        config.setAutoCertRefreshSeconds((String) getParameter(messageContext,
-                PulsarConstants.AUTO_CERT_REFRESH_SECONDS));
 
         return config;
     }

--- a/src/main/java/org/wso2/integration/connector/connection/PulsarConnectionSetup.java
+++ b/src/main/java/org/wso2/integration/connector/connection/PulsarConnectionSetup.java
@@ -87,9 +87,6 @@ public class PulsarConnectionSetup {
         if (secureConfig.getTlsTrustStoreType() != null) {
             clientBuilder.tlsTrustStoreType(secureConfig.getTlsTrustStoreType());
         }
-        if (secureConfig.getAutoCertRefreshSeconds() != null) {
-            clientBuilder.autoCertRefreshSeconds(secureConfig.getAutoCertRefreshSeconds());
-        }
 
         return clientBuilder;
     }

--- a/src/main/java/org/wso2/integration/connector/pojo/PulsarSecureConnectionConfig.java
+++ b/src/main/java/org/wso2/integration/connector/pojo/PulsarSecureConnectionConfig.java
@@ -34,7 +34,6 @@ public class PulsarSecureConnectionConfig extends PulsarConnectionConfig {
     private String tlsTrustStorePath;
     private String tlsTrustStorePassword;
     private String tlsTrustStoreType;
-    private Integer autoCertRefreshSeconds;
 
     public Boolean useTls() {
         return useTls;
@@ -137,16 +136,6 @@ public class PulsarSecureConnectionConfig extends PulsarConnectionConfig {
     public void setTlsTrustStoreType(String tlsTrustStoreType) {
         if (StringUtils.isNotEmpty(tlsTrustStoreType)) {
             this.tlsTrustStoreType = tlsTrustStoreType;
-        }
-    }
-
-    public Integer getAutoCertRefreshSeconds() {
-        return autoCertRefreshSeconds;
-    }
-
-    public void setAutoCertRefreshSeconds(String autoCertRefreshSeconds) {
-        if (StringUtils.isNotEmpty(autoCertRefreshSeconds)) {
-            this.autoCertRefreshSeconds = Integer.parseInt(autoCertRefreshSeconds);
         }
     }
 

--- a/src/main/java/org/wso2/integration/connector/utils/PulsarConstants.java
+++ b/src/main/java/org/wso2/integration/connector/utils/PulsarConstants.java
@@ -76,7 +76,6 @@ public class PulsarConstants {
     public static final String AUTH_PARAM_MAP = "authParamMap";
     public static final String AUTH_PARAMS = "authParams";
     public static final String AUTH_PLUGIN_CLASS_NAME = "authPluginClassName";
-    public static final String AUTO_CERT_REFRESH_SECONDS = "autoCertRefreshSeconds";
     public static final String JWT_TOKEN = "jwtToken";
 
     // Pulsar producer configuration constants
@@ -95,7 +94,6 @@ public class PulsarConstants {
     public static final String MESSAGE_ROUTING_MODE = "messageRoutingMode";
     public static final String CHUNKING_ENABLED = "chunkingEnabled";
     public static final String CHUNK_MAX_MESSAGE_SIZE = "chunkMaxMessageSize";
-    public static final String CRYPTO_FAILURE_ACTION = "cryptoFailureAction";
 
     // Pulsar message configuration constants
     public static final String KEY = "key";

--- a/src/main/resources/pulsar_config/init.xml
+++ b/src/main/resources/pulsar_config/init.xml
@@ -26,7 +26,6 @@
     <parameter name="numListenerThreads" description="Number of listener threads for Pulsar client."/>
     <parameter name="useTcpNoDelay" description="Enable TCP no delay for network connections."/>
     <parameter name="requestTimeoutMs" description="Timeout for requests (in milliseconds)."/>
-    <parameter name="maxLookupRequests" description="Maximum number of lookup requests allowed on each broker connection."/>
     <parameter name="maxConcurrentLookupRequests" description="Maximum number of concurrent lookup requests allowed on each broker connection."/>
     <parameter name="maxRejectedRequestsPerConnection" description="Maximum number of rejected requests per connection."/>
     <parameter name="keepAliveIntervalSeconds" description="Keep-alive interval for broker connections (in seconds)."/>
@@ -44,7 +43,7 @@
     <parameter name="listenerName" description="Listener name for the Pulsar client."/>
     <parameter name="lookupTimeoutMs" description="Timeout for lookup requests (in milliseconds)."/>
     <parameter name="maxLookupRedirects" description="Maximum number of lookup redirects allowed."/>
-    <parameter name="maxLookupRequest" description="Maximum number of lookup requests."/>
+    <parameter name="maxLookupRequest" description="Maximum number of lookup requests allowed on each broker connection to prevent overloading a broker."/>
     <parameter name="maxNumberOfRejectedRequestPerConnection" description="Maximum number of rejected requests per connection."/>
     <parameter name="memoryLimitBytes" description="Memory limit for Pulsar client (in bytes)."/>
     <parameter name="tlsTrustCertsFilePath" description="Path to the TLS trust certificates file."/>
@@ -62,7 +61,6 @@
     <parameter name="tlsKeyStoreType" description="Type of the TLS key store."/>
     <parameter name="tlsKeyStorePath" description="Path to the TLS key store."/>
     <parameter name="tlsKeyStorePassword" description="Password for the TLS key store."/>
-    <parameter name="autoCertRefreshSeconds" description="Interval for automatic certificate refresh (in seconds)."/>
     <parameter name="authenticationType" description="Type of authentication (e.g., JWT, TLS, OAUTH2, NONE)."/>
     <parameter name="authParamMap" description="Map of authentication parameters."/>
     <parameter name="authParams" description="Authentication parameters string."/>
@@ -78,7 +76,6 @@
         <property expression="$func:numListenerThreads" name="pulsar.numListenerThreads"/>
         <property expression="$func:useTcpNoDelay" name="pulsar.useTcpNoDelay"/>
         <property expression="$func:requestTimeoutMs" name="pulsar.requestTimeoutMs"/>
-        <property expression="$func:maxLookupRequests" name="pulsar.maxLookupRequests"/>
         <property expression="$func:maxConcurrentLookupRequests" name="pulsar.maxConcurrentLookupRequests"/>
         <property expression="$func:maxRejectedRequestsPerConnection" name="pulsar.maxRejectedRequestsPerConnection"/>
         <property expression="$func:keepAliveIntervalSeconds" name="pulsar.keepAliveIntervalSeconds"/>
@@ -119,7 +116,6 @@
         <property expression="$func:authParamMap" name="pulsar.authParamMap"/>
         <property expression="$func:authParams" name="pulsar.authParams"/>
         <property expression="$func:authPluginClassName" name="pulsar.authPluginClassName"/>
-        <property expression="$func:autoCertRefreshSeconds" name="pulsar.autoCertRefreshSeconds"/>
         <class name="org.wso2.integration.connector.PulsarConfig"/>
     </sequence>
 </template>

--- a/src/main/resources/pulsar_produce/pulsarProduceTemplate.xml
+++ b/src/main/resources/pulsar_produce/pulsarProduceTemplate.xml
@@ -32,7 +32,6 @@
     <parameter name="maxPendingMessagesAcrossPartitions" description="The maximum number of pending messages across all partitions. This is useful for partitioned topics."/>
     <parameter name="hashingScheme" description="The hashing scheme used to determine the partition for a message. Supported values: JavaStringHash, Murmur3_32Hash, BoostHash."/>
     <parameter name="messageRoutingMode" description="The message routing mode for partitioned topics. Supported values: SinglePartition, RoundRobinPartition, CustomPartition."/>
-    <parameter name="cryptoFailureAction" description="The action to take when message encryption fails. Supported values: FAIL, SEND."/>
     <parameter name="key" description="The key associated with the message for partitioning or routing."/>
     <parameter name="value" description="The value or payload of the message to be published."/>
     <parameter name="properties" description="Custom properties to attach to the message as key-value pairs."/>

--- a/src/main/resources/uischema/publishMessage.json
+++ b/src/main/resources/uischema/publishMessage.json
@@ -349,21 +349,6 @@
                             "CustomPartition"
                           ]
                         }
-                      },
-                      {
-                        "type": "attribute",
-                        "value": {
-                          "name": "cryptoFailureAction",
-                          "displayName": "Crypto Failure Action",
-                          "inputType": "combo",
-                          "defaultValue": "FAIL",
-                          "required": "false",
-                          "helpTip": "The action to take when message encryption fails. Supported values: FAIL, SEND.",
-                          "comboValues": [
-                            "FAIL",
-                            "SEND"
-                          ]
-                        }
                       }
                     ]
                   }

--- a/src/main/resources/uischema/secureConnection.json
+++ b/src/main/resources/uischema/secureConnection.json
@@ -224,23 +224,6 @@
           {
             "type": "attribute",
             "value": {
-              "name": "autoCertRefreshSeconds",
-              "displayName": "Auto Certificate Refresh Interval (in seconds)",
-              "inputType": "stringOrExpression",
-              "validateType": "number",
-              "defaultValue": "",
-              "required": "false",
-              "helpTip": "Interval in seconds to automatically refresh TLS certificates.",
-              "enableCondition": [
-                {
-                  "tlsAllowInsecureConnection": "false"
-                }
-              ]
-            }
-          },
-          {
-            "type": "attribute",
-            "value": {
               "name": "enableTlsHostnameVerification",
               "displayName": "Enable TLS Hostname Verification",
               "inputType": "boolean",


### PR DESCRIPTION
## Purpose
This PR adds support for processing inline expressions for message properties. Additionally, it removes `autoCertRefreshSeconds` and  `cryptoFailureAction ` config parameters as they are irrelevant for the current Pulsar connector implementation. 